### PR TITLE
Pull request - Fixed NullPointerException, Added feature to support HttpUrlConnection fixedStreamingMode

### DIFF
--- a/library/src/com/android/volley/Request.java
+++ b/library/src/com/android/volley/Request.java
@@ -312,7 +312,7 @@ public abstract class Request<T> implements Comparable<Request<T>> {
      */
     public String getUrl() {
 		try {
-	    	if(mMethod == Method.GET && getParams().size() != 0){
+	    	if(mMethod == Method.GET && (getParams() != null && getParams().size() != 0)){
 	            String encodedParams = getEncodedUrlParams();
 	            String extra = "";
 	            if (encodedParams != null && encodedParams.length() > 0) {

--- a/library/src/com/android/volley/request/MultiPartRequest.java
+++ b/library/src/com/android/volley/request/MultiPartRequest.java
@@ -24,6 +24,7 @@ public abstract class MultiPartRequest<T> extends Request<T> implements Progress
 	private Map<String, MultiPartParam> mMultipartParams = null;
 	private Map<String, String> mFileUploads = null;
 	public static final int TIMEOUT_MS = 30000;
+	private boolean isFixedStreamingMode;
 
     /**
      * Creates a new request with the given method.
@@ -129,5 +130,13 @@ public abstract class MultiPartRequest<T> extends Request<T> implements Progress
 	 */
 	public String getProtocolCharset() {
 		return PROTOCOL_CHARSET;
+	}
+
+	public boolean isFixedStreamingMode() {
+		return isFixedStreamingMode;
+	}
+	
+	public void setFixedStreamingMode(boolean isFixedStreamingMode) {
+		this.isFixedStreamingMode = isFixedStreamingMode;
 	}
 }


### PR DESCRIPTION
pull request no. 1
Fixed NullPointerException	 f819fd8

It occurred in case of special situation



pull request no. 2
Added feature to support HttpUrlConnection fixedStreamingMode	 5b3f282

VolleyPlus currently only supports chunkedStreamingMode.
Old versions of ngix failed to process the request based on chunk. Then it replies to the following status code.

statusCode 411 - ContentLength required

So I added a feature that allows you to use fixedLengthStreamingMode.