### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/library/src/com/android/volley/misc/MultipartUtils.java
+++ b/library/src/com/android/volley/misc/MultipartUtils.java
@@ -42,20 +42,20 @@ public class MultipartUtils {
     public static int getContentLengthForMultipartRequest(String boundary, Map<String, MultiPartRequest.MultiPartParam> multipartParams, Map<String, String> filesToUpload) {
         final int boundaryLength = boundary.getBytes().length;
         int contentLength = 0;
-        for (String key : multipartParams.keySet()) {
-            MultiPartRequest.MultiPartParam param = multipartParams.get(key);
+        for (Map.Entry<String, MultiPartRequest.MultiPartParam> multipartParam : multipartParams.entrySet()) {
+            MultiPartRequest.MultiPartParam param = multipartParam.getValue();
             int size = boundaryLength +
-                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA, key).getBytes().length +
+                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA, multipartParam.getKey()).getBytes().length +
                     CRLF_LENGTH + HEADER_CONTENT_TYPE_LENGTH + COLON_SPACE_LENGTH + param.contentType.getBytes().length +
                     CRLF_LENGTH + CRLF_LENGTH + param.value.getBytes().length + CRLF_LENGTH;
 
             contentLength += size;
         }
 
-        for (String key : filesToUpload.keySet()) {
-            File file = new File(filesToUpload.get(key));
+        for (Map.Entry<String, String> filetoUpload : filesToUpload.entrySet()) {
+            File file = new File(filetoUpload.getValue());
             int size = boundaryLength +
-                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA + SEMICOLON_SPACE + FILENAME, key, file.getName()).getBytes().length +
+                    CRLF_LENGTH + HEADER_CONTENT_DISPOSITION_LENGTH + COLON_SPACE_LENGTH + String.format(FORM_DATA + SEMICOLON_SPACE + FILENAME, filetoUpload.getKey(), file.getName()).getBytes().length +
                     CRLF_LENGTH + HEADER_CONTENT_TYPE_LENGTH + COLON_SPACE_LENGTH + CONTENT_TYPE_OCTET_STREAM_LENGTH +
                     CRLF_LENGTH + HEADER_CONTENT_TRANSFER_ENCODING_LENGTH + COLON_SPACE_LENGTH + BINARY_LENGTH + CRLF_LENGTH + CRLF_LENGTH;
 

--- a/library/src/com/android/volley/toolbox/HttpClientStack.java
+++ b/library/src/com/android/volley/toolbox/HttpClientStack.java
@@ -65,16 +65,16 @@ public class HttpClientStack implements HttpStack {
 	}
 
 	private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-		for (String key : headers.keySet()) {
-			httpRequest.setHeader(key, headers.get(key));
+		for (Map.Entry<String, String> header : headers.entrySet()) {
+			httpRequest.setHeader(header.getKey(), header.getValue());
 		}
 	}
 
 	@SuppressWarnings("unused")
 	private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
 		List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
-		for (String key : postParams.keySet()) {
-			result.add(new BasicNameValuePair(key, postParams.get(key)));
+		for (Map.Entry<String, String> postParam : postParams.entrySet()) {
+			result.add(new BasicNameValuePair(postParam.getKey(), postParam.getValue()));
 		}
 		return result;
 	}
@@ -165,12 +165,12 @@ public class HttpClientStack implements HttpStack {
 			final Map<String, MultiPartParam> multipartParams = ((MultiPartRequest<?>) request).getMultipartParams();
 			final Map<String, String> filesToUpload = ((MultiPartRequest<?>) request).getFilesToUpload();
 
-			for (String key : multipartParams.keySet()) {
-				multipartEntity.addPart(new StringPart(key, multipartParams.get(key).value));
+			for (Map.Entry<String, MultiPartParam> multipartParam : multipartParams.entrySet()) {
+				multipartEntity.addPart(new StringPart(multipartParam.getKey(), multipartParam.getValue().value));
 			}
 
-			for (String key : filesToUpload.keySet()) {
-				File file = new File(filesToUpload.get(key));
+			for (Map.Entry<String, String> fileToUpload : filesToUpload.entrySet()) {
+				File file = new File(fileToUpload.getValue());
 
 				if (!file.exists()) {
 					throw new IOException(String.format("File not found: %s", file.getAbsolutePath()));
@@ -180,7 +180,7 @@ public class HttpClientStack implements HttpStack {
 					throw new IOException(String.format("File is a directory: %s", file.getAbsolutePath()));
 				}
 
-				FilePart filePart = new FilePart(key, file, null, null);
+				FilePart filePart = new FilePart(fileToUpload.getKey(), file, null, null);
 				multipartEntity.addPart(filePart);
 			}
 			httpRequest.setEntity(multipartEntity);

--- a/library/src/com/android/volley/toolbox/HurlStack.java
+++ b/library/src/com/android/volley/toolbox/HurlStack.java
@@ -138,8 +138,8 @@ public class HurlStack implements HttpStack {
 			connection.setRequestProperty(HEADER_USER_AGENT, mUserAgent);
 		}
 
-		for (String headerName : map.keySet()) {
-			connection.addRequestProperty(headerName, map.get(headerName));
+		for (Entry<String, String> header : map.entrySet()) {
+			connection.addRequestProperty(header.getKey(), header.getValue());
 		}
 		if (request instanceof MultiPartRequest) {
 			setConnectionParametersForMultipartRequest(connection, request);
@@ -225,17 +225,17 @@ public class HurlStack implements HttpStack {
 			OutputStream out = connection.getOutputStream();
 			writer = new PrintWriter(new OutputStreamWriter(out, charset), true);
 
-			for (String key : multipartParams.keySet()) {
-				MultiPartParam param = multipartParams.get(key);
+			for (Entry<String, MultiPartParam> multipartParam : multipartParams.entrySet()) {
+				MultiPartParam param = multipartParam.getValue();
 
-				writer.append(boundary).append(CRLF).append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA, key)).append(CRLF)
+				writer.append(boundary).append(CRLF).append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA, multipartParam.getKey())).append(CRLF)
 						.append(HEADER_CONTENT_TYPE + COLON_SPACE + param.contentType).append(CRLF).append(CRLF).append(param.value).append(CRLF)
 						.flush();
 			}
 
-			for (String key : filesToUpload.keySet()) {
+			for (Entry<String, String> fileToUpload : filesToUpload.entrySet()) {
 
-				File file = new File(filesToUpload.get(key));
+				File file = new File(fileToUpload.getValue());
 
 				if (!file.exists()) {
 					throw new IOException(String.format("File not found: %s", file.getAbsolutePath()));
@@ -247,7 +247,7 @@ public class HurlStack implements HttpStack {
 
 				writer.append(boundary)
 						.append(CRLF)
-						.append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA + SEMICOLON_SPACE + FILENAME, key, file.getName()))
+						.append(String.format(HEADER_CONTENT_DISPOSITION + COLON_SPACE + FORM_DATA + SEMICOLON_SPACE + FILENAME, fileToUpload.getKey(), file.getName()))
 						.append(CRLF).append(HEADER_CONTENT_TYPE + COLON_SPACE + CONTENT_TYPE_OCTET_STREAM).append(CRLF)
 						.append(HEADER_CONTENT_TRANSFER_ENCODING + COLON_SPACE + BINARY).append(CRLF).append(CRLF).flush();
 

--- a/sample/src/com/volley/demo/misc/ExtHttpClientStack.java
+++ b/sample/src/com/volley/demo/misc/ExtHttpClientStack.java
@@ -59,16 +59,16 @@ public class ExtHttpClientStack implements HttpStack {
 	}
 
 	private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-		for (String key : headers.keySet()) {
-			httpRequest.setHeader(key, headers.get(key));
+		for (Map.Entry<String, String> header : headers.entrySet()) {
+			httpRequest.setHeader(header.getKey(), header.getValue());
 		}
 	}
 
 	@SuppressWarnings("unused")
 	private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
 		List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
-		for (String key : postParams.keySet()) {
-			result.add(new BasicNameValuePair(key, postParams.get(key)));
+		for (Map.Entry<String, String> postParam : postParams.entrySet()) {
+			result.add(new BasicNameValuePair(postParam.getKey(), postParam.getValue()));
 		}
 		return result;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed