### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/library/src/com/android/volley/VolleyLog.java
+++ b/library/src/com/android/volley/VolleyLog.java
@@ -25,6 +25,9 @@ import android.util.Log;
 
 /** Logging helper class. */
 public class VolleyLog {
+
+    private VolleyLog() {}
+
     public static String TAG = "Volley";
 
     public static boolean DEBUG = BuildConfig.DEBUG;//Log.isLoggable(TAG, Log.VERBOSE);

--- a/library/src/com/android/volley/error/VolleyErrorHelper.java
+++ b/library/src/com/android/volley/error/VolleyErrorHelper.java
@@ -11,6 +11,9 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 public class VolleyErrorHelper {
+
+	private VolleyErrorHelper() {}
+
 	/**
 	 * 
 	 * @param error

--- a/library/src/com/android/volley/misc/Exif.java
+++ b/library/src/com/android/volley/misc/Exif.java
@@ -22,6 +22,9 @@ import java.io.InputStream;
 import android.util.Log;
 
 public class Exif {
+
+    private Exif() {}
+
     private static final String TAG = "CameraExif";
 
     /**

--- a/library/src/com/android/volley/misc/IOUtils.java
+++ b/library/src/com/android/volley/misc/IOUtils.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class IOUtils {
+
+    private IOUtils() {}
+
     /*
      * Homebrewed simple serialization system used for reading and writing cache
      * headers on disk. Once upon a time, this used the standard Java

--- a/library/src/com/android/volley/misc/MultipartUtils.java
+++ b/library/src/com/android/volley/misc/MultipartUtils.java
@@ -13,6 +13,8 @@ import java.util.Map;
  */
 public class MultipartUtils {
 
+    private MultipartUtils() {}
+
     public static final String CRLF = "\r\n";
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
     public static final String HEADER_USER_AGENT = "User-Agent";

--- a/library/src/com/android/volley/misc/NetUtils.java
+++ b/library/src/com/android/volley/misc/NetUtils.java
@@ -22,6 +22,9 @@ import android.content.pm.PackageManager;
 import android.util.Log;
 
 public class NetUtils {
+
+    private NetUtils() {}
+
     private static final String TAG = "NetUtils";
     private static String mUserAgent = null;
 

--- a/library/src/com/android/volley/misc/Trace.java
+++ b/library/src/com/android/volley/misc/Trace.java
@@ -23,6 +23,9 @@ import android.os.Build;
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 public abstract class Trace {
+
+	private Trace() {}
+
 	/**
 	 * Begins systrace tracing for a given tag. No-op on unsupported platform
 	 * versions.

--- a/library/src/com/android/volley/misc/ViewCompat.java
+++ b/library/src/com/android/volley/misc/ViewCompat.java
@@ -22,6 +22,8 @@ import android.view.View;
 
 
 public class ViewCompat {
+
+	private ViewCompat() {}
 	
 	@SuppressLint("NewApi")
 	@SuppressWarnings("deprecation")

--- a/library/src/com/android/volley/toolbox/HttpHeaderParser.java
+++ b/library/src/com/android/volley/toolbox/HttpHeaderParser.java
@@ -34,6 +34,8 @@ import com.android.volley.NetworkResponse;
  */
 public class HttpHeaderParser {
 
+    private HttpHeaderParser() {}
+
     /**
      * Extracts a {@link Cache.Entry} from a {@link NetworkResponse}.
      *

--- a/library/src/com/android/volley/toolbox/Volley.java
+++ b/library/src/com/android/volley/toolbox/Volley.java
@@ -29,6 +29,8 @@ import com.android.volley.misc.Utils;
 
 public class Volley {
 
+    private Volley() {}
+
     /** Default on-disk cache directory. */
     private static final String DEFAULT_CACHE_DIR = "volley";
 

--- a/library/src/com/android/volley/toolbox/VolleyTickle.java
+++ b/library/src/com/android/volley/toolbox/VolleyTickle.java
@@ -32,6 +32,8 @@ import com.android.volley.misc.Utils;
 
 public class VolleyTickle {
 
+    private VolleyTickle() {}
+
     /** Default on-disk cache directory. */
     private static final String DEFAULT_CACHE_DIR = "volley";
 

--- a/library/src/com/android/volley/toolbox/multipart/UrlEncodingHelper.java
+++ b/library/src/com/android/volley/toolbox/multipart/UrlEncodingHelper.java
@@ -7,6 +7,8 @@ import org.apache.http.protocol.HTTP;
 
 public class UrlEncodingHelper {
 
+    private UrlEncodingHelper() {}
+
     public static String encode(final String content, final String encoding) {
         try {
             return URLEncoder.encode(

--- a/sample/src/com/volley/demo/util/Images.java
+++ b/sample/src/com/volley/demo/util/Images.java
@@ -21,6 +21,8 @@ package com.volley.demo.util;
  */
 public class Images {
 
+    private Images() {}
+
     /**
      * This are PicasaWeb URLs and could potentially change. Ideally the PicasaWeb API should be
      * used to fetch the URLs.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed